### PR TITLE
Update runtime to 6.10

### DIFF
--- a/io.github.KikoPlayProject.KikoPlay.yaml
+++ b/io.github.KikoPlayProject.KikoPlay.yaml
@@ -125,6 +125,7 @@ modules:
         config-opts:
           - -DCMAKE_BUILD_TYPE=Release
           - -DBUILD_STATIC=0
+          - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         sources:
           - type: git
             url: https://gitlab.freedesktop.org/uchardet/uchardet.git


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10, and 5.15-25.08) provides FFMPEG; therefore, declaring org.freedesktop.Platform.ffmpeg-full extension is no longer required.

Fixes https://github.com/flathub/io.github.KikoPlayProject.KikoPlay/issues/124